### PR TITLE
Add more geo-viewport versions

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -332,6 +332,24 @@
                 "files": [
                     "geo-viewport.js"
                 ]
+            },
+        "v": {
+            "0.2.0": {
+                "files": [
+                    "geo-viewport.js"
+                ]
+            }
+        "v": {
+            "0.2.1": {
+                "files": [
+                    "geo-viewport.js"
+                ]
+            },
+        "v": {
+            "0.2.2": {
+                "files": [
+                    "geo-viewport.js"
+                ]
             }
         }
     },


### PR DESCRIPTION
Sam from Mapbox support pointed me to this file as I was not able to use the URL listed in https://github.com/mapbox/geo-viewport README.

I presume that the files `plugins` also need adding but I am not sure what the process is to generate them.

I was also not sure which releases should be added.